### PR TITLE
Amélioration des warnings lorsque la condition est un ET ou un OU

### DIFF
--- a/app/models/classement.rb
+++ b/app/models/classement.rb
@@ -11,11 +11,11 @@ class Classement < ApplicationRecord
 
   def human_readable_volume
     words = (volume || '').split
-    return volume if words.length > 2 || words.length.zero?
+    return volume if words.length.zero?
 
     volume_number = simplify_volume(words.first || '')
-    volume_unit = words.length == 1 ? '' : words.last
-    volume_unit.empty? ? volume_number.to_s : "#{volume_number} #{volume_unit}"
+    volume_unit = words[1..].join(' ')
+    "#{volume_number} #{volume_unit}".strip
   end
 
   def float?(string)

--- a/app/resources/parametrization/warnings.rb
+++ b/app/resources/parametrization/warnings.rb
@@ -50,23 +50,46 @@ module Parametrization
     end
 
     def and_human_condition(condition)
-      child_conditions = condition.conditions.map { |child| human_condition(child) }.sort
-      [child_conditions[..-2].join(', '), child_conditions[-1]].join(' et ')
+      humanize_and_aggregate(condition.conditions, ' et ')
     end
 
     def or_human_condition(condition)
-      child_conditions = condition.conditions.map { |child| human_condition(child) }.sort
-      [child_conditions[..-2].join(', '), child_conditions[-1]].join(' ou ')
+      humanize_and_aggregate(condition.conditions, ' ou ')
+    end
+
+    def humanize_and_aggregate(conditions, separator)
+      return humanize_similar_equal_conditions(conditions, separator) if similar_equal_conditions?(conditions)
+
+      child_conditions = conditions.map { |child| human_condition(child) }.sort
+      join_with_comma_and_separator(child_conditions, separator)
+    end
+
+    def similar_equal_conditions?(conditions)
+      return false unless conditions.all? { |child| child.type == 'EQUAL' }
+
+      conditions.map(&:parameter).map(&:id).uniq.size == 1
+    end
+
+    def humanize_similar_equal_conditions(conditions, separator)
+      parameter = conditions.first.parameter
+      targets = conditions.map(&:target).map { |target| human_parameter_value(parameter.id, target) }.sort
+      "#{human_parameter(parameter)} est #{join_with_comma_and_separator(targets, separator)}"
+    end
+
+    def join_with_comma_and_separator(strings, separator)
+      return strings.first if strings.length == 1
+
+      [strings[..-2].join(', '), strings[-1]].join(separator)
     end
 
     def equal_human_condition(condition)
-      return equal_regime_human_condition(condition.target) if condition.parameter.type == 'REGIME'
-
-      "#{human_parameter(condition.parameter)} est #{condition.target}"
+      "#{human_parameter(condition.parameter)} est #{human_parameter_value(condition.parameter.id, condition.target)}"
     end
 
-    def equal_regime_human_condition(regime)
-      "le régime de classement est #{human_regime(regime)}"
+    def human_parameter_value(parameter_id, value)
+      return human_regime(value) if parameter_id == 'regime'
+
+      value
     end
 
     def human_regime(regime)
@@ -126,13 +149,13 @@ module Parametrization
 
       case parameter.id
       when 'regime'
-        'le régime'
+        'le régime de classement'
       when 'rubrique'
         'la rubrique'
       when 'quantite-rubrique'
         'la quantité associée à la rubrique'
       when 'alinea'
-        "l'alinea de classement"
+        "l'alinéa de classement"
       else
         raise "Unknown parameter #{parameter.id}"
       end

--- a/spec/models/classement_spec.rb
+++ b/spec/models/classement_spec.rb
@@ -43,11 +43,6 @@ RSpec.describe Classement do
       expect(classement.human_readable_volume).to eq ''
     end
 
-    it 'does not transform volume when volume has more than one space' do
-      classement = described_class.new(volume: '10.000 m3 t')
-      expect(classement.human_readable_volume).to eq '10.000 m3 t'
-    end
-
     it 'removes useless trailing zeros for integer values' do
       classement = described_class.new(volume: '10.000 m3')
       expect(classement.human_readable_volume).to eq '10 m3'
@@ -66,6 +61,16 @@ RSpec.describe Classement do
     it 'removes useless trailing zeros even when volume has no unit' do
       classement = described_class.new(volume: '10.000')
       expect(classement.human_readable_volume).to eq '10'
+    end
+
+    it 'removes useless trailing zeros even when volume has no unit and trailing whitespace' do
+      classement = described_class.new(volume: '10.000 ')
+      expect(classement.human_readable_volume).to eq '10'
+    end
+
+    it 'simplifies volume when volume has more than one space' do
+      classement = described_class.new(volume: '10.000 m3 t')
+      expect(classement.human_readable_volume).to eq '10 m3 t'
     end
   end
 end


### PR DESCRIPTION
- à merger après https://github.com/Envinorma/envinorma-web/pull/257

- seul le commit `improve warnings for AND and OR` fait partie de cette PR

- implémente ceci : https://github.com/Envinorma/envinorma-web/issues/260