### PR TITLE
Utiliser les paramètres en commun lorsqu'il y a plusieurs classements

### DIFF
--- a/app/controllers/concerns/filter_ams.rb
+++ b/app/controllers/concerns/filter_ams.rb
@@ -61,7 +61,7 @@ module FilterAMs
     return [true, potentially_inapplicable_arrete_warning(condition)] if classements.length != 1
 
     classement = classements.first
-    parameters = parameter_dict(classement)
+    parameters = parameter_hash(classement)
 
     return [false, inapplicable_arrete_warning(condition)] if satisfied?(condition, parameters)
 

--- a/app/models/classement.rb
+++ b/app/models/classement.rb
@@ -11,11 +11,11 @@ class Classement < ApplicationRecord
 
   def human_readable_volume
     words = (volume || '').split
-    return volume if words.length > 2 || words.length.zero?
+    return volume if words.length.zero?
 
     volume_number = simplify_volume(words.first || '')
-    volume_unit = words.length == 1 ? '' : words.last
-    volume_unit.empty? ? volume_number.to_s : "#{volume_number} #{volume_unit}"
+    volume_unit = words[1..].join(' ')
+    "#{volume_number} #{volume_unit}".strip
   end
 
   def float?(string)

--- a/app/resources/parametrization/parameters.rb
+++ b/app/resources/parametrization/parameters.rb
@@ -94,13 +94,12 @@ module Parametrization
     def handle_inapplicabilities(section, parameters)
       warnings = []
       section.parametrization.potential_inapplicabilities.each do |inapplicability|
-        if satisfied?(inapplicability.condition, parameters)
+        condition = inapplicability.condition
+        if satisfied?(condition, parameters)
           deactivate_alineas(section, inapplicability.alineas)
           return [true, [inapplicability_warning(inapplicability)]]
-        elsif potentially_satisfied?(inapplicability.condition, parameters)
-          is_a_modification = inapplicability.alineas.present?
-          # if only some alineas are inapplicable, it's a modification
-          warnings << potentially_satisfied_warning(inapplicability.condition, is_a_modification)
+        elsif potentially_satisfied?(condition, parameters)
+          warnings << potentially_satisfied_warning(condition, false, inapplicability.alineas)
         end
       end
       [false, warnings]

--- a/app/resources/parametrization/warnings.rb
+++ b/app/resources/parametrization/warnings.rb
@@ -14,9 +14,15 @@ module Parametrization
       "Cette section a été modifiée car #{human_condition(modification.condition)}."
     end
 
-    def potentially_satisfied_warning(condition, is_a_modification)
-      adjective = is_a_modification ? 'modifiée' : 'inapplicable'
-      "Cette section pourrait être #{adjective}. C'est le cas si #{human_condition(condition)}."
+    def potentially_satisfied_warning(condition, is_a_modification, alineas = nil)
+      first_sentence = if is_a_modification
+                         'Cette section pourrait être modifiée'
+                       elsif alineas.blank?
+                         'Cette section pourrait être inapplicable'
+                       else
+                         potentially_inapplicable_alineas_sentence(alineas)
+                       end
+      "#{first_sentence}. C'est le cas si #{human_condition(condition)}."
     end
 
     def inapplicable_arrete_warning(condition)
@@ -172,6 +178,24 @@ module Parametrization
       else
         raise "Unknown parameter #{parameter_id}"
       end
+    end
+
+    def potentially_inapplicable_alineas_sentence(alineas)
+      raise ArgumentError, 'No alineas' if alineas.empty?
+
+      alineas = alineas.map { |alinea| alinea + 1 }.sort # For human readability
+
+      return "L'alinéa #{alineas[0]} pourrait être inapplicable" if alineas.size == 1
+
+      if range_of_size_three_at_least?(alineas)
+        return "Les alinéas #{alineas.min} à #{alineas.max} pourraient être inapplicables"
+      end
+
+      "Les alinéas #{join_with_comma_and_separator(alineas, ' et ')} pourraient être inapplicables"
+    end
+
+    def range_of_size_three_at_least?(alineas)
+      alineas.size >= 3 && alineas.length == alineas.uniq.max - alineas.min + 1
     end
   end
 end

--- a/app/resources/parametrization/warnings.rb
+++ b/app/resources/parametrization/warnings.rb
@@ -50,23 +50,46 @@ module Parametrization
     end
 
     def and_human_condition(condition)
-      child_conditions = condition.conditions.map { |child| human_condition(child) }.sort
-      [child_conditions[..-2].join(', '), child_conditions[-1]].join(' et ')
+      humanize_and_aggregate(condition.conditions, ' et ')
     end
 
     def or_human_condition(condition)
-      child_conditions = condition.conditions.map { |child| human_condition(child) }.sort
-      [child_conditions[..-2].join(', '), child_conditions[-1]].join(' ou ')
+      humanize_and_aggregate(condition.conditions, ' ou ')
+    end
+
+    def humanize_and_aggregate(conditions, separator)
+      return humanize_similar_equal_conditions(conditions, separator) if similar_equal_conditions?(conditions)
+
+      child_conditions = conditions.map { |child| human_condition(child) }.sort
+      join_with_comma_and_separator(child_conditions, separator)
+    end
+
+    def similar_equal_conditions?(conditions)
+      return false unless conditions.all? { |child| child.type == 'EQUAL' }
+
+      conditions.map(&:parameter).map(&:id).uniq.size == 1
+    end
+
+    def humanize_similar_equal_conditions(conditions, separator)
+      parameter = conditions.first.parameter
+      targets = conditions.map(&:target).map { |target| human_parameter_value(parameter.id, target) }.sort
+      "#{human_parameter(parameter)} est #{join_with_comma_and_separator(targets, separator)}"
+    end
+
+    def join_with_comma_and_separator(strings, separator)
+      return strings.first if strings.length == 1
+
+      [strings[..-2].join(', '), strings[-1]].join(separator)
     end
 
     def equal_human_condition(condition)
-      return equal_regime_human_condition(condition.target) if condition.parameter.type == 'REGIME'
-
-      "#{human_parameter(condition.parameter)} est #{condition.target}"
+      "#{human_parameter(condition.parameter)} est #{human_parameter_value(condition.parameter.id, condition.target)}"
     end
 
-    def equal_regime_human_condition(regime)
-      "le régime de classement est #{human_regime(regime)}"
+    def human_parameter_value(parameter_id, value)
+      return human_regime(value) if parameter_id == 'regime'
+
+      value
     end
 
     def human_regime(regime)
@@ -126,13 +149,13 @@ module Parametrization
 
       case parameter.id
       when 'regime'
-        'le régime'
+        'le régime de classement'
       when 'rubrique'
         'la rubrique'
       when 'quantite-rubrique'
         'la quantité associée à la rubrique'
       when 'alinea'
-        "l'alinea de classement"
+        "l'alinéa de classement"
       else
         raise "Unknown parameter #{parameter.id}"
       end

--- a/spec/features/am_with_inapplicability_spec.rb
+++ b/spec/features/am_with_inapplicability_spec.rb
@@ -23,13 +23,23 @@ RSpec.describe 'test consult AM with inapplicability', js: true do
     expect(page).to have_content('date de mise en service est antérieure')
   end
 
-  it 'displays potentially inapplicable paragraph if there are two classements' do
+  it 'displays potentially inapplicable paragraph if there are two classements with different dates' do
+    FactoryBot.create(:classement, :classement_2521_E,
+                      installation: Installation.first, date_mise_en_service: '2000-01-02'.to_date)
+    FactoryBot.create(:classement, :classement_2521_E,
+                      installation: Installation.first, date_mise_en_service: '2000-01-01'.to_date)
+    visit arretes_path(Installation.first, am_ids: AM.all.pluck(:id))
+    expect(page).to have_content('Cette section pourrait être inapplicable')
+    expect(page).to have_content('date de mise en service est antérieure')
+  end
+
+  it 'displays inapplicable paragraph if there are two classements with the same date' do
     FactoryBot.create(:classement, :classement_2521_E,
                       installation: Installation.first, date_mise_en_service: '2000-01-01'.to_date)
     FactoryBot.create(:classement, :classement_2521_E,
                       installation: Installation.first, date_mise_en_service: '2000-01-01'.to_date)
     visit arretes_path(Installation.first, am_ids: AM.all.pluck(:id))
-    expect(page).to have_content('Cette section pourrait être inapplicable')
+    expect(page).to have_content('Cette section est inapplicable')
     expect(page).to have_content('date de mise en service est antérieure')
   end
 end

--- a/spec/models/classement_spec.rb
+++ b/spec/models/classement_spec.rb
@@ -43,11 +43,6 @@ RSpec.describe Classement do
       expect(classement.human_readable_volume).to eq ''
     end
 
-    it 'does not transform volume when volume has more than one space' do
-      classement = described_class.new(volume: '10.000 m3 t')
-      expect(classement.human_readable_volume).to eq '10.000 m3 t'
-    end
-
     it 'removes useless trailing zeros for integer values' do
       classement = described_class.new(volume: '10.000 m3')
       expect(classement.human_readable_volume).to eq '10 m3'
@@ -66,6 +61,16 @@ RSpec.describe Classement do
     it 'removes useless trailing zeros even when volume has no unit' do
       classement = described_class.new(volume: '10.000')
       expect(classement.human_readable_volume).to eq '10'
+    end
+
+    it 'removes useless trailing zeros even when volume has no unit and trailing whitespace' do
+      classement = described_class.new(volume: '10.000 ')
+      expect(classement.human_readable_volume).to eq '10'
+    end
+
+    it 'simplifies volume when volume has more than one space' do
+      classement = described_class.new(volume: '10.000 m3 t')
+      expect(classement.human_readable_volume).to eq '10 m3 t'
     end
   end
 end

--- a/spec/resources/parametrization/parameters_spec.rb
+++ b/spec/resources/parametrization/parameters_spec.rb
@@ -12,25 +12,20 @@ RSpec.describe Parametrization::Parameters do
     JSON.parse(File.read(path), object_class: OpenStruct)
   end
 
-  describe 'classements_parameter_dict' do
-    it 'returns empty dict for no classements' do
-      expect(classements_parameter_dict([])).to eq({})
+  describe 'classements_parameter_hash' do
+    it 'returns empty hash for no classements' do
+      expect(classements_parameter_hash([])).to eq({})
     end
 
-    it 'returns empty dict if several classements with different regime' do
+    it 'returns hash with common parameters' do
       classements = [
-        FactoryBot.create(:classement, :classement_2521_E, regime: 'E'),
-        FactoryBot.create(:classement, :classement_2521_E, regime: 'A')
+        FactoryBot.create(:classement, :classement_2521_E),
+        FactoryBot.create(:classement, :classement_2521_E, alinea: '2', rubrique: '2522')
       ]
-      expect(classements_parameter_dict(classements)).to eq({})
-    end
-
-    it 'returns dict with regime if several classements with same regime' do
-      classements = [
-        FactoryBot.create(:classement, :classement_2521_E, regime: 'E'),
-        FactoryBot.create(:classement, :classement_2521_E, regime: 'E')
-      ]
-      expect(classements_parameter_dict(classements)).to eq({ 'regime' => 'E' })
+      expected = { 'regime' => 'E',
+                   'date-d-enregistrement' => 'Tue, 07 May 1974'.to_date,
+                   'date-d-installation' => 'Tue, 07 May 1974'.to_date }
+      expect(classements_parameter_hash(classements)).to eq(expected)
     end
   end
 
@@ -65,6 +60,21 @@ RSpec.describe Parametrization::Parameters do
       deactivate_alineas(section, [0])
       children_alineas = section.sections.map(&:outer_alineas).flatten.map(&:active)
       expect(children_alineas).to all(be(true))
+    end
+  end
+
+  describe 'keep_identical_values' do
+    it 'returns input hash if only one hash is in list' do
+      expect(keep_identical_values([{ 'regime' => 'E', 'alinea' => '1' }])).to eq({ 'regime' => 'E', 'alinea' => '1' })
+    end
+
+    it 'returns merged hash on identical values' do
+      hashes = [
+        { 'regime' => 'E', 'alinea' => '1', 'rubrique' => '1510' },
+        { 'regime' => 'E', 'alinea' => '2' },
+        { 'regime' => 'E', 'rubrique' => '1510' }
+      ]
+      expect(keep_identical_values(hashes)).to eq({ 'regime' => 'E' })
     end
   end
 

--- a/spec/resources/parametrization/warnings_spec.rb
+++ b/spec/resources/parametrization/warnings_spec.rb
@@ -138,6 +138,12 @@ RSpec.describe Parametrization::Warnings do
       expect(potentially_satisfied_warning(regime_enregistrement, true)).to eq(expected)
     end
 
+    it 'generates potential alinea inapplicability warning with equal target' do
+      expected = "L'alinéa 1 pourrait être inapplicable. C'est le cas si "\
+                 "le régime de classement est l'enregistrement."
+      expect(potentially_satisfied_warning(regime_enregistrement, false, [0])).to eq(expected)
+    end
+
     it 'generates potential inapplicability warning with equal target' do
       expected = "Cette section pourrait être inapplicable. C'est le cas si "\
                  "le régime de classement est l'enregistrement."
@@ -213,6 +219,45 @@ RSpec.describe Parametrization::Warnings do
     it 'joins three elements with comma and separator' do
       merged_sentence = join_with_comma_and_separator(['this is a cat', 'this is a dog', 'this is a mouse'], ' and ')
       expect(merged_sentence).to eq('this is a cat, this is a dog and this is a mouse')
+    end
+  end
+
+  describe 'potentially_inapplicable_alineas_sentence' do
+    it 'raises error if called with empty list' do
+      expect { potentially_inapplicable_alineas_sentence([]) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns sentence with targeted alinea if there is only one alinea' do
+      expected = 'L\'alinéa 3 pourrait être inapplicable'
+      expect(potentially_inapplicable_alineas_sentence([2])).to eq(expected)
+    end
+
+    it 'returns sentence with index list if there is a non-mergeable list of alineas' do
+      expected = 'Les alinéas 3, 4 et 7 pourraient être inapplicables'
+      expect(potentially_inapplicable_alineas_sentence([6, 2, 3])).to eq(expected)
+    end
+
+    it 'returns sentence with merged index list if there is a mergeable list of alineas' do
+      expected = 'Les alinéas 3 à 7 pourraient être inapplicables'
+      expect(potentially_inapplicable_alineas_sentence([6, 2, 3, 4, 5])).to eq(expected)
+    end
+  end
+
+  describe 'range_of_size_three_at_least?' do
+    it 'returns false if there is only one element' do
+      expect(range_of_size_three_at_least?([1])).to be false
+    end
+
+    it 'returns false if there are two elements' do
+      expect(range_of_size_three_at_least?([1, 2])).to be false
+    end
+
+    it 'returns true if there are three consecutive elements' do
+      expect(range_of_size_three_at_least?([1, 3, 2])).to be true
+    end
+
+    it 'returns false if there are three non consecutive elements' do
+      expect(range_of_size_three_at_least?([6, 3, 4])).to be false
     end
   end
 end


### PR DESCRIPTION
- à merger après #263 
- seul le commit `use common parameters among classements` fait partie de cette PR
- implémente cet issue: https://github.com/Envinorma/envinorma-web/issues/259